### PR TITLE
fix(auto): 修复 Android Auto 无法使用的问题

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,8 @@ dependencies {
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.car.app)
+    // Android Auto（投屏）专用实现，缺失时车机侧功能不完整。
+    implementation(libs.androidx.car.app.projected)
     implementation(libs.androidx.datastore.preferences)
     // 百度普通 Android 导航 SDK（本地 AAR 开发包，已包含 地图/定位/搜索/导航 全部模块）
     // BaiduLBS_Android.aar = 地图+定位+搜索+工具 all-in-one

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,6 +71,8 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <!-- 声明为地图类应用，便于系统/语音助手把导航请求交给灰猫地图。 -->
+                <category android:name="android.intent.category.APP_MAPS" />
             </intent-filter>
         </activity>
 
@@ -93,6 +95,30 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="baidunaviauto" android:host="navigate" />
+            </intent-filter>
+
+            <!--
+              Android Auto / 语音助手 / 第三方 POI 应用下发目的地时使用的导航意图。
+              Car App Library 明确要求：投屏（Android Auto）场景下 NAVIGATE 意图过滤器
+              必须声明在 Activity 上（而不是 CarAppService 上），否则车机端无法把目的地
+              交给本应用，只能一直停留在“请在手机端选择目的地并开始导航”的提示界面。
+              参考：https://developer.android.com/training/cars/apps/navigation
+            -->
+            <intent-filter>
+                <action android:name="androidx.car.app.action.NAVIGATE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="geo" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="geo" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="google.navigation" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/huimao/map/navigation/NavCarService.kt
+++ b/app/src/main/java/com/huimao/map/navigation/NavCarService.kt
@@ -7,11 +7,13 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.view.Surface
 import android.view.View
 import androidx.car.app.AppManager
 import androidx.car.app.CarAppService
 import androidx.car.app.CarContext
+import androidx.car.app.CarToast
 import androidx.car.app.Screen
 import androidx.car.app.Session
 import androidx.car.app.SurfaceCallback
@@ -35,6 +37,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.baidu.navisdk.adapter.BaiduNaviManagerFactory
 import com.baidu.navisdk.adapter.IBNMiniMapViewManager
+import com.huimao.map.ui.LocationRedirectActivity
 import java.util.Locale
 import java.util.TimeZone
 
@@ -44,7 +47,41 @@ class NavCarService : CarAppService() {
 }
 
 class NavCarSession : Session() {
-    override fun onCreateScreen(intent: Intent): Screen = CarMainScreen(carContext)
+
+    override fun onCreateScreen(intent: Intent): Screen {
+        handleNavigationIntent(intent)
+        return CarMainScreen(carContext)
+    }
+
+    /** 会话已存在时，车机主机会通过 onNewIntent 下发新的导航请求。 */
+    override fun onNewIntent(intent: Intent) {
+        handleNavigationIntent(intent)
+    }
+
+    /**
+     * 处理 Android Auto / 语音助手下发的 [CarContext.ACTION_NAVIGATE]（geo: / google.navigation:）。
+     *
+     * 百度导航引擎只能在手机端 NaviActivity 中初始化，因此这里把目的地转交给
+     * LocationRedirectActivity，由它完成坐标转换并启动导航；导航一旦开始，
+     * CarNavigationBridge 会驱动车机端模板与地图画面。
+     */
+    private fun handleNavigationIntent(intent: Intent) {
+        if (intent.action != CarContext.ACTION_NAVIGATE) return
+        val data = intent.data ?: return
+        val handoff = Intent(Intent.ACTION_VIEW, data)
+            .setClass(carContext, LocationRedirectActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val started = runCatching { carContext.startActivity(handoff) }
+            .onFailure { android.util.Log.e("NavCarBaidu", "navigate intent handoff failed", it) }
+            .isSuccess
+        runCatching {
+            CarToast.makeText(
+                carContext,
+                if (started) "正在手机端规划路线…" else "请解锁手机后重试",
+                CarToast.LENGTH_LONG
+            ).show()
+        }
+    }
 }
 
 class CarMainScreen(carContext: CarContext) : Screen(carContext) {
@@ -59,14 +96,60 @@ class CarMainScreen(carContext: CarContext) : Screen(carContext) {
     private var miniMapCreated = false
     private var miniMapView: View? = null
     private var lastBaiduBitmapAt = 0L
+    private var tickerScheduled = false
+    private var pendingInvalidate = false
+    private var lastInvalidateAt = 0L
 
     private val frameTicker = object : Runnable {
         override fun run() {
             if (carSurface?.isValid == true && CarNavigationBridge.state.navigating) {
                 renderMap()
-                frameHandler.postDelayed(this, 250L)
+                frameHandler.postDelayed(this, FRAME_INTERVAL_MS)
+            } else {
+                // 导航还没开始或 Surface 已失效：结束本轮循环，并允许后续状态变化时重启。
+                tickerScheduled = false
             }
         }
+    }
+
+    /**
+     * 车机 Surface 通常在导航开始之前就已就绪，此时 frameTicker 第一次执行就会退出。
+     * 之前的实现只在 onSurfaceAvailable 中 post ticker，导致刷新循环永久停摆，
+     * 车机端表现为黑屏或画面冻结。这里在每次状态变化时确保循环处于运行状态。
+     */
+    private fun ensureFrameTicker() {
+        if (tickerScheduled) return
+        if (carSurface?.isValid != true || !CarNavigationBridge.state.navigating) return
+        tickerScheduled = true
+        frameHandler.removeCallbacks(frameTicker)
+        frameHandler.post(frameTicker)
+    }
+
+    private val invalidateRunnable = Runnable {
+        pendingInvalidate = false
+        lastInvalidateAt = SystemClock.uptimeMillis()
+        invalidate()
+    }
+
+    /**
+     * 车机主机对模板刷新有速率限制，超限会被主机判定为异常应用并断开连接。
+     * 手机端每 300ms 推送一帧画面、每秒回调定位，都会触发 bridgeListener，
+     * 因此把模板刷新限流到 [MIN_INVALIDATE_INTERVAL_MS]；
+     * Surface 上的地图画面仍由 frameTicker 按 [FRAME_INTERVAL_MS] 独立重绘。
+     */
+    private fun scheduleInvalidate() {
+        if (pendingInvalidate) return
+        pendingInvalidate = true
+        val delay = (lastInvalidateAt + MIN_INVALIDATE_INTERVAL_MS - SystemClock.uptimeMillis())
+            .coerceIn(0L, MIN_INVALIDATE_INTERVAL_MS)
+        frameHandler.postDelayed(invalidateRunnable, delay)
+    }
+
+    private fun invalidateNow() {
+        frameHandler.removeCallbacks(invalidateRunnable)
+        pendingInvalidate = false
+        lastInvalidateAt = SystemClock.uptimeMillis()
+        invalidate()
     }
 
     private val surfaceCallback = object : SurfaceCallback {
@@ -81,12 +164,14 @@ class CarMainScreen(carContext: CarContext) : Screen(carContext) {
             miniMapView?.let { layoutMiniMapView(it) }
             renderMap()
             frameHandler.removeCallbacks(frameTicker)
-            frameHandler.post(frameTicker)
+            tickerScheduled = false
+            ensureFrameTicker()
         }
 
         override fun onSurfaceDestroyed(container: SurfaceContainer) {
             if (carSurface === container.surface) carSurface = null
             frameHandler.removeCallbacks(frameTicker)
+            tickerScheduled = false
         }
     }
 
@@ -95,7 +180,8 @@ class CarMainScreen(carContext: CarContext) : Screen(carContext) {
             publishTrip()
             ensureMiniMap()
             renderMap()
-            invalidate()
+            ensureFrameTicker()
+            scheduleInvalidate()
         }
     }
 
@@ -113,6 +199,9 @@ class CarMainScreen(carContext: CarContext) : Screen(carContext) {
         lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onDestroy(owner: LifecycleOwner) {
                 frameHandler.removeCallbacks(frameTicker)
+                frameHandler.removeCallbacks(invalidateRunnable)
+                tickerScheduled = false
+                pendingInvalidate = false
                 appManager.setSurfaceCallback(null)
                 carSurface = null
                 if (miniMapCreated) runCatching {
@@ -166,11 +255,19 @@ class CarMainScreen(carContext: CarContext) : Screen(carContext) {
                 .setHeaderAction(Action.APP_ICON)
                 .build()
         }
-        val step = Step.Builder(state.instruction)
-            .setRoad(state.roadName.ifBlank { state.instruction })
-            .setManeuver(Maneuver.Builder(
+        // 非法/不完整的转向类型（例如环岛缺少出口编号）会让 Maneuver.Builder 抛异常，
+        // 而 onGetTemplate 抛异常会直接导致车机端应用崩溃，这里做兜底。
+        val maneuver = runCatching {
+            Maneuver.Builder(
                 state.maneuverType.takeIf { it != 0 } ?: Maneuver.TYPE_STRAIGHT
-            ).build()).build()
+            ).build()
+        }.getOrElse {
+            android.util.Log.w("NavCarBaidu", "invalid maneuver type ${state.maneuverType}", it)
+            Maneuver.Builder(Maneuver.TYPE_STRAIGHT).build()
+        }
+        val step = Step.Builder(state.instruction.ifBlank { "继续行驶" })
+            .setRoad(state.roadName.ifBlank { state.instruction.ifBlank { "继续行驶" } })
+            .setManeuver(maneuver).build()
         val routingDistance = state.distanceToTurnMeters.takeIf { it > 0 }
             ?: state.remainingDistanceMeters.coerceAtLeast(1)
         val routing = RoutingInfo.Builder()
@@ -186,7 +283,7 @@ class CarMainScreen(carContext: CarContext) : Screen(carContext) {
             CarNavigationBridge.stop()
             runCatching { navigationManager.navigationEnded() }
             navigationAnnounced = false
-            invalidate()
+            invalidateNow()
         }.build()
         return NavigationTemplate.Builder()
             .setNavigationInfo(routing)
@@ -350,4 +447,12 @@ class CarMainScreen(carContext: CarContext) : Screen(carContext) {
     private fun displayDistance(meters: Int): Distance = if (meters >= 1000) {
         Distance.create(meters / 1000.0, Distance.UNIT_KILOMETERS_P1)
     } else Distance.create(meters.toDouble(), Distance.UNIT_METERS)
+
+    private companion object {
+        /** 车机地图画面重绘间隔。 */
+        const val FRAME_INTERVAL_MS = 250L
+
+        /** 模板刷新最小间隔，避免触发车机主机的模板速率限制。 */
+        const val MIN_INVALIDATE_INTERVAL_MS = 1_000L
+    }
 }

--- a/app/src/main/java/com/huimao/map/ui/LocationRedirectActivity.kt
+++ b/app/src/main/java/com/huimao/map/ui/LocationRedirectActivity.kt
@@ -4,10 +4,28 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
 
-/** 接收微信地图代理转发的位置，坐标约定为百度 BD09LL。 */
+/**
+ * 接收外部导航请求并转交给 [NaviActivity]。
+ *
+ * 支持三类来源：
+ * 1. 微信地图代理转发：`baidunaviauto://navigate?lat=&lng=&name=`，坐标约定为百度 BD09LL；
+ * 2. Android Auto / 语音助手下发的导航意图：`androidx.car.app.action.NAVIGATE` + `geo:`；
+ * 3. 通用地图意图：`geo:` 与 `google.navigation:`。
+ *
+ * 注意：只有内部的 `baidunaviauto://` 协议使用 BD09LL；按 Android 平台约定，
+ * `geo:` / `google.navigation:` 携带的是 WGS-84 坐标，必须先转换成 BD09LL
+ * 再交给百度导航，否则目的地会出现数百米的偏移。
+ */
 class LocationRedirectActivity : Activity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handle(intent)
@@ -20,15 +38,149 @@ class LocationRedirectActivity : Activity() {
 
     private fun handle(intent: Intent) {
         val uri = intent.data
-        val lat = uri?.getQueryParameter("lat")?.toDoubleOrNull() ?: 0.0
-        val lng = uri?.getQueryParameter("lng")?.toDoubleOrNull() ?: 0.0
-        val name = uri?.getQueryParameter("name")?.takeIf { it.isNotBlank() } ?: "微信位置"
-        if (lat !in -90.0..90.0 || lng !in -180.0..180.0 || lat == 0.0 || lng == 0.0) {
-            Toast.makeText(this, "微信位置坐标无效", Toast.LENGTH_LONG).show()
-            finish()
+        if (uri == null) {
+            Log.w(TAG, "missing data uri, action=${intent.action}")
+            toastAndFinish("未收到导航目的地")
             return
         }
-        NaviActivity.start(applicationContext, lat, lng, name)
+        val target = parseTarget(uri)
+        if (target == null) {
+            Log.w(TAG, "unsupported navigation uri: $uri")
+            toastAndFinish("该导航请求缺少有效坐标，请在应用内搜索目的地")
+            return
+        }
+        Log.i(TAG, "navigate to ${target.name} (${target.lat}, ${target.lng}) from scheme=${uri.scheme}")
+        NaviActivity.start(applicationContext, target.lat, target.lng, target.name)
         finish()
+    }
+
+    private fun toastAndFinish(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+        finish()
+    }
+
+    private fun parseTarget(uri: Uri): Target? = when (uri.scheme?.lowercase()) {
+        "baidunaviauto" -> parseInternal(uri)
+        "geo" -> parseGeo(uri)
+        "google.navigation" -> parseGoogleNavigation(uri)
+        else -> null
+    }
+
+    /** 内部协议，坐标已是 BD09LL，无需转换。 */
+    private fun parseInternal(uri: Uri): Target? {
+        val lat = uri.getQueryParameter("lat")?.toDoubleOrNull() ?: return null
+        val lng = uri.getQueryParameter("lng")?.toDoubleOrNull() ?: return null
+        if (!isValid(lat, lng)) return null
+        val name = uri.getQueryParameter("name")?.takeIf { it.isNotBlank() } ?: "微信位置"
+        return Target(lat, lng, name)
+    }
+
+    /**
+     * `geo:39.9,116.4`、`geo:39.9,116.4?z=16`、`geo:0,0?q=39.9,116.4(公司)`。
+     *
+     * `geo:` 属于 opaque URI，[Uri.getQueryParameter] 会抛 UnsupportedOperationException，
+     * 因此这里手动解析 schemeSpecificPart。
+     */
+    private fun parseGeo(uri: Uri): Target? {
+        val ssp = uri.schemeSpecificPart ?: return null
+        val path = ssp.substringBefore('?')
+        val query = ssp.substringAfter('?', "")
+        val point = queryValue(query, "q")?.let { parsePoint(it) }?.takeIf { isValid(it.lat, it.lng) }
+            ?: parsePoint(path)?.takeIf { isValid(it.lat, it.lng) }
+            ?: return null
+        return toBaiduTarget(point)
+    }
+
+    /** `google.navigation:q=39.9,116.4&mode=d`、`google.navigation:ll=39.9,116.4`。 */
+    private fun parseGoogleNavigation(uri: Uri): Target? {
+        val query = uri.schemeSpecificPart ?: return null
+        val point = queryValue(query, "ll")?.let { parsePoint(it) }?.takeIf { isValid(it.lat, it.lng) }
+            ?: queryValue(query, "q")?.let { parsePoint(it) }?.takeIf { isValid(it.lat, it.lng) }
+            ?: return null
+        return toBaiduTarget(point)
+    }
+
+    /** 解析 `lat,lng`、`lat,lng(名称)`、`loc:lat,lng` 形式的文本。 */
+    private fun parsePoint(text: String): Point? {
+        val decoded = Uri.decode(text.trim()).trim()
+        if (decoded.isEmpty()) return null
+        val label = decoded.substringAfter('(', "").substringBeforeLast(')').takeIf { it.isNotBlank() }
+        val coords = decoded.substringBefore('(').trim().removePrefix("loc:").trim()
+        val parts = coords.split(',')
+        if (parts.size < 2) return null
+        val lat = parts[0].trim().toDoubleOrNull() ?: return null
+        val lng = parts[1].trim().substringBefore('&').trim().toDoubleOrNull() ?: return null
+        return Point(lat, lng, label)
+    }
+
+    private fun queryValue(query: String, key: String): String? {
+        if (query.isEmpty()) return null
+        return query.split('&')
+            .asSequence()
+            .mapNotNull { pair ->
+                val index = pair.indexOf('=')
+                if (index <= 0) null else pair.substring(0, index) to pair.substring(index + 1)
+            }
+            .firstOrNull { it.first.equals(key, ignoreCase = true) }
+            ?.second
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    private fun isValid(lat: Double, lng: Double): Boolean =
+        lat in -90.0..90.0 && lng in -180.0..180.0 && (abs(lat) > 1e-6 || abs(lng) > 1e-6)
+
+    /** 外部意图坐标为 WGS-84，转换为百度 BD09LL。 */
+    private fun toBaiduTarget(point: Point): Target {
+        val gcj = wgs84ToGcj02(point.lat, point.lng)
+        val bd09 = gcj02ToBd09(gcj.first, gcj.second)
+        return Target(bd09.first, bd09.second, point.label ?: "导航目的地")
+    }
+
+    private fun wgs84ToGcj02(lat: Double, lng: Double): Pair<Double, Double> {
+        if (outOfChina(lat, lng)) return lat to lng
+        var dLat = transformLat(lng - 105.0, lat - 35.0)
+        var dLng = transformLng(lng - 105.0, lat - 35.0)
+        val radLat = lat / 180.0 * Math.PI
+        var magic = sin(radLat)
+        magic = 1 - EE * magic * magic
+        val sqrtMagic = sqrt(magic)
+        dLat = dLat * 180.0 / (SEMI_MAJOR_AXIS * (1 - EE) / (magic * sqrtMagic) * Math.PI)
+        dLng = dLng * 180.0 / (SEMI_MAJOR_AXIS / sqrtMagic * cos(radLat) * Math.PI)
+        return (lat + dLat) to (lng + dLng)
+    }
+
+    private fun gcj02ToBd09(lat: Double, lng: Double): Pair<Double, Double> {
+        val z = sqrt(lng * lng + lat * lat) + 0.00002 * sin(lat * Math.PI * 3000.0 / 180.0)
+        val theta = atan2(lat, lng) + 0.000003 * cos(lng * Math.PI * 3000.0 / 180.0)
+        return (z * sin(theta) + 0.006) to (z * cos(theta) + 0.0065)
+    }
+
+    private fun outOfChina(lat: Double, lng: Double): Boolean =
+        lng < 72.004 || lng > 137.8347 || lat < 0.8293 || lat > 55.8271
+
+    private fun transformLat(x: Double, y: Double): Double {
+        var ret = -100.0 + 2.0 * x + 3.0 * y + 0.2 * y * y + 0.1 * x * y + 0.2 * sqrt(abs(x))
+        ret += (20.0 * sin(6.0 * x * Math.PI) + 20.0 * sin(2.0 * x * Math.PI)) * 2.0 / 3.0
+        ret += (20.0 * sin(y * Math.PI) + 40.0 * sin(y / 3.0 * Math.PI)) * 2.0 / 3.0
+        ret += (160.0 * sin(y / 12.0 * Math.PI) + 320.0 * sin(y * Math.PI / 30.0)) * 2.0 / 3.0
+        return ret
+    }
+
+    private fun transformLng(x: Double, y: Double): Double {
+        var ret = 300.0 + x + 2.0 * y + 0.1 * x * x + 0.1 * x * y + 0.1 * sqrt(abs(x))
+        ret += (20.0 * sin(6.0 * x * Math.PI) + 20.0 * sin(2.0 * x * Math.PI)) * 2.0 / 3.0
+        ret += (20.0 * sin(x * Math.PI) + 40.0 * sin(x / 3.0 * Math.PI)) * 2.0 / 3.0
+        ret += (150.0 * sin(x / 12.0 * Math.PI) + 300.0 * sin(x / 30.0 * Math.PI)) * 2.0 / 3.0
+        return ret
+    }
+
+    private data class Point(val lat: Double, val lng: Double, val label: String?)
+
+    private data class Target(val lat: Double, val lng: Double, val name: String)
+
+    private companion object {
+        const val TAG = "LocationRedirect"
+        const val SEMI_MAJOR_AXIS = 6378245.0
+        const val EE = 0.00669342162296594323
     }
 }

--- a/docs/ANDROID_AUTO.md
+++ b/docs/ANDROID_AUTO.md
@@ -1,0 +1,86 @@
+# Android Auto 接入与排障
+
+本文档记录灰猫地图在 Android Auto（手机投屏，非 Automotive OS）上的接入要点、
+已知问题与排查顺序。
+
+## 1. 依赖与声明
+
+| 项目 | 要求 | 说明 |
+| --- | --- | --- |
+| `androidx.car.app:app` | 必需 | Car App Library 核心库 |
+| `androidx.car.app:app-projected` | 必需 | Android Auto（投屏）专用实现，官方 `Declaring dependencies` 明确要求与核心库一起引入 |
+| `com.google.android.gms.car.application` meta-data | 必需 | 指向 `@xml/automotive_app_desc`，Android Auto 靠它识别应用 |
+| `@xml/automotive_app_desc` | 必需 | 至少包含 `<uses name="template"/>` |
+| `CarAppService` + `androidx.car.app.category.NAVIGATION` | 必需 | 导航类模板应用 |
+| `androidx.car.app.NAVIGATION_TEMPLATES` / `ACCESS_SURFACE` | 必需 | 使用 `NavigationTemplate` 与自绘 Surface |
+| `androidx.car.app.action.NAVIGATE` intent-filter | 必需 | **必须声明在 Activity 上**（投屏场景），否则车机/语音助手无法下发目的地 |
+
+参考：
+
+- <https://developer.android.com/training/cars/apps/navigation>
+- <https://developer.android.com/jetpack/androidx/releases/car-app>
+
+## 2. 导航意图
+
+车机端与语音助手通过下列意图下发目的地，`LocationRedirectActivity` 负责解析：
+
+```text
+androidx.car.app.action.NAVIGATE  geo:39.915,116.404
+androidx.car.app.action.NAVIGATE  geo:0,0?q=39.915,116.404(天安门)
+android.intent.action.VIEW        google.navigation:q=39.915,116.404
+android.intent.action.VIEW        baidunaviauto://navigate?lat=&lng=&name=   # 内部协议
+```
+
+坐标系约定：
+
+- `geo:` / `google.navigation:` 为 **WGS-84**，需转换为 **BD09LL** 后再交给百度导航；
+- `baidunaviauto://` 为内部协议，已是 **BD09LL**，不做转换。
+
+`NavCarSession` 同时实现 `onCreateScreen()` 与 `onNewIntent()`：会话冷启动与热启动
+两条路径都要处理导航意图，否则第二次下发目的地会没有反应。
+
+## 3. 车机端画面刷新
+
+- 地图画面：`SurfaceCallback` 拿到车机 Surface 后，按 250ms 周期把百度 MiniMap 的
+  位图绘制到 Surface；`ensureFrameTicker()` 保证导航开始后刷新循环一定处于运行状态
+  （Surface 往往在导航开始之前就绪，早期实现会让刷新循环永久停摆并导致黑屏）。
+- 模板刷新：车机主机对模板刷新有速率限制，超限会被断开。手机端每 300ms 推帧、
+  每秒回调定位，因此 `invalidate()` 被限流到 1s 一次。
+
+## 4. 排查顺序
+
+1. **应用是否出现在 Android Auto 启动器？**
+   - 非 Google Play 渠道安装（自签 APK / 侧载）必须在 Android Auto 中开启
+     开发者选项，并勾选「未知来源的应用」；
+   - 确认 Android Auto 与 Google Play 服务已是最新版本；
+   - 确认 `automotive_app_desc` 与 `CarAppService` 声明未被打包剥离。
+2. **应用能打开但一直提示「请在手机端选择目的地并开始导航」？**
+   - 说明车机侧会话正常，但 `CarNavigationBridge.navigating` 仍为 false；
+   - 用语音助手或第三方 POI 应用下发一次导航意图验证 NAVIGATE 链路；
+   - 检查手机端百度导航是否真的启动成功（见下一条）。
+3. **手机端导航起不来？**
+   - 必须配置真实的百度地图 AK（`PLACEHOLDER_AK` 会直接失败），且 AK 的包名
+     `com.huimao.map` 与签名 SHA-1 必须与实际安装包一致；
+   - 关注 `initFailed`、`路线规划失败`、`15 秒内未获取到当前位置` 等错误提示；
+   - 定位 `locType=68` 表示 AK 鉴权失败。
+4. **车机有界面但地图黑屏 / 画面冻结？**
+   - 抓取日志过滤 `NavCarBaidu` 与 `NaviActivity`；
+   - 检查是否有 `Baidu background map init failed`；
+   - 确认手机端 `NaviActivity` 仍在前台（当前架构下百度导航引擎依赖该 Activity）。
+
+调试命令：
+
+```bash
+adb logcat -s NavCarBaidu NaviActivity LocationRedirect CarApp
+```
+
+桌面头单元（DHU）可在没有真实车机的情况下验证：
+<https://developer.android.com/training/cars/testing/dhu>
+
+## 5. 已知遗留问题（待后续处理）
+
+- `NavCarService.createHostValidator()` 使用 `ALLOW_ALL_HOSTS_VALIDATOR`，
+  正式版建议改为「debug 允许全部 + release 使用主机白名单」。
+- 百度导航引擎目前只能在手机端 `NaviActivity` 中初始化，手机侧 Activity 被回收后
+  车机端会立即失去导航状态；更稳妥的做法是把导航状态与定位放进前台 Service。
+- 车机端仍无法独立选择目的地（没有搜索/收藏/最近目的地界面），只能接收导航意图。

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-car-app = { group = "androidx.car.app", name = "app", version.ref = "carApp" }
+# Android Auto（投屏）专用实现，官方文档要求与 androidx.car.app:app 一起引入。
+androidx-car-app-projected = { group = "androidx.car.app", name = "app-projected", version.ref = "carApp" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 baidu-search = { group = "com.baidu.lbsyun", name = "BaiduMapSDK_Search", version = "8.1.0" }
 baidu-util = { group = "com.baidu.lbsyun", name = "BaiduMapSDK_Util", version = "8.1.0" }


### PR DESCRIPTION
关注一下 xtawa 谢谢哦
1. 补齐 Android Auto 专用依赖 androidx.car.app:app-projected（官方文档要求， 仅依赖 androidx.car.app:app 时缺少投屏侧实现）。
2. 车机端无法下发目的地：新增 androidx.car.app.action.NAVIGATE / geo: / google.navigation: 意图过滤器（Car App Library 要求声明在 Activity 上）， 并在 Session 中实现 onNewIntent + onCreateScreen 的导航意图处理， 否则车机端永远停留在“请在手机端选择目的地并开始导航”。
3. LocationRedirectActivity 支持解析 geo:/google.navigation: 目的地，并把 WGS-84 坐标转换为百度 BD09LL（原实现只认内部 baidunaviauto:// 协议且 直接按 BD09LL 处理，外部意图坐标会偏移）。
4. 修复车机 Surface 刷新循环永久停摆：frameTicker 只在 onSurfaceAvailable 中 post，若 Surface 先就绪、导航后开始，ticker 首次执行即退出且不再重启， 导致车机地图黑屏/画面冻结。改为 ensureFrameTicker() 在状态变化时恢复。
5. 模板刷新限流：手机端每 300ms 推帧 + 定位回调会触发高频 invalidate()， 超过车机主机模板速率限制会被断开；现在限流到 1s，地图仍按 250ms 重绘。
6. onGetTemplate() 增加 Maneuver 兜底，避免非法转向类型抛异常导致车机崩溃。
7. 新增 docs/ANDROID_AUTO.md 排障文档。